### PR TITLE
#31 allow to use /usr/share/cppcmsskel/ instead of /usr/local/share/cppcmsskel/ by default

### DIFF
--- a/tools/create_new_cppcmsskel
+++ b/tools/create_new_cppcmsskel
@@ -7,7 +7,10 @@ import os
 
 
 #TODO replace this by 
-CPPCMS_SKEL_DEFAULT_INSTALL_DIR = '/usr/local/share/cppcmsskel/'
+if os.path.exists('/usr/share/cppcmsskel/'):
+    CPPCMS_SKEL_DEFAULT_INSTALL_DIR = '/usr/share/cppcmsskel/'
+else:
+    CPPCMS_SKEL_DEFAULT_INSTALL_DIR = '/usr/local/share/cppcmsskel/'
 
 if __name__ == '__main__':
     parser = ArgumentParser(

--- a/tools/init.py
+++ b/tools/init.py
@@ -20,7 +20,10 @@ from architecture import generate_architecture, generate_folders
 from config import ARCHITECTURE, APP_ROOT, REPLACEMENTS
 from constants import FOLDERS, LOCAL_TEMPLATE_ROOT, MAIN_APP_PLACEHOLDER
 
-CPPCMS_SKEL_DEFAULT_INSTALL_DIR = '/usr/local/share/cppcmsskel/'
+if os.path.exists('/usr/share/cppcmsskel/'):
+    CPPCMS_SKEL_DEFAULT_INSTALL_DIR = '/usr/share/cppcmsskel/'
+else:
+    CPPCMS_SKEL_DEFAULT_INSTALL_DIR = '/usr/local/share/cppcmsskel/'
 
 IGNORE_DIRS = [
     'tools',


### PR DESCRIPTION
This patch allows to install to /usr/share/cppcmsskel/ instead of default /usr/local/share/cppcmsskel/.

If you have other ideas how to solve this problem, please let me know.

This PR closes #31
