### PR TITLE
Fix image upload temporary path

### DIFF
--- a/cppcms_skel/models/Uploads.cpp
+++ b/cppcms_skel/models/Uploads.cpp
@@ -40,9 +40,8 @@ std::string Uploads::save(
     try {
         //TODO if we keep the same name, we should then check that there's
         // not already a file with the same name
-        file->save_to(filename);
-        std::rename(
-            filename.c_str(),
+        file->write_data();
+        file->save_to(
             (Config::get_upload_folder() + filename).c_str()
         );
     } catch (cppcms::cppcms_error const &e) {


### PR DESCRIPTION
Use cppcms’ temporary path instead of saving the incoming file into the current working directory.

This allows tatowiki to be run under an unprivileged user without causing permission problems for uploads.
